### PR TITLE
consume(): запись за границу буфера librdkafka при чтении тела сообщения

### DIFF
--- a/src/consumer_methods.cpp
+++ b/src/consumer_methods.cpp
@@ -441,7 +441,11 @@ std::string SimpleKafka1C::consume()
 
 		jsonObj.put("partition", msg->partition());
 		jsonObj.put("offset", (long)msg->offset());
-		jsonObj.put("message", std::string(slice(payload, 0, msg->len())));
+		// Тело берём по паре (указатель, длина). Прежний slice(payload, 0, len)
+		// копировал байты [0..len] включительно и дописывал завершающий ноль,
+		// то есть читал payload[len] и писал payload[len+1] — за границу буфера
+		// librdkafka. Плюс лишний проход по телу и обрыв на первом нуле.
+		jsonObj.put("message", std::string(payload, msg->len()));
 		jsonObj.put("topic", msg->topic_name());
 		jsonObj.put("broker_id", msg->broker_id());
 		jsonObj.put("timestamp", ts.timestamp);


### PR DESCRIPTION
### Что происходит

`Consume` собирает тело сообщения так:

```cpp
jsonObj.put("message", std::string(slice(payload, 0, msg->len())));
```

а `slice()` (`src/utils.cpp`) копирует байты `[from..to]` **включительно** и дописывает завершающий ноль:

```cpp
for (size_t i = from; i <= to; ++i) s[j++] = s[i];
s[j] = 0;
```

При `to = msg->len()` это чтение `payload[len]` и запись `payload[len+1]` — оба за границей буфера, которым владеет librdkafka. Тихая порча соседних байт в её пуле, а на границе страницы — падение процесса. Проявляется редко и невоспроизводимо, поэтому легко списывается на что-то другое.

Побочно: тело переписывается на месте лишним проходом, а `std::string` из `char*` обрывается на первом нулевом байте — для бинарных тел (avro, protobuf) это ещё и потеря данных.

### Что в PR

Строка строится по паре указатель-длина: `std::string(payload, msg->len())`. Одна строка плюс комментарий, поведение для текстовых тел не меняется, для бинарных становится корректным.

`slice()` после этого в коде не используется. Трогать `utils.h` в этом PR не стал — на ваше усмотрение.
