### PR TITLE
Консьюмер: сообщения под unique_ptr (утечка на исключении), мьютекс на offsets ребаланса

### DIFF
--- a/src/SimpleKafka1C.cpp
+++ b/src/SimpleKafka1C.cpp
@@ -314,6 +314,7 @@ void SimpleKafka1C::clRebalanceCb::rebalance_cb(RdKafka::KafkaConsumer* consumer
 	RdKafka::ErrorCode err,
 	std::vector<RdKafka::TopicPartition*>& partitions) 
 	{
+	std::lock_guard<std::mutex> lk(offsetsMtx);
 	if (err == RdKafka::ERR__ASSIGN_PARTITIONS) 
 	{
 		if (offsets.size()) 
@@ -557,11 +558,14 @@ SimpleKafka1C::~SimpleKafka1C()
 	stopProducer();
 
 	// Очистка rebalance callback offsets для предотвращения утечки памяти
-	for (auto* offset : cl_rebalance_cb.offsets)
 	{
-		delete offset;
+		std::lock_guard<std::mutex> lk(cl_rebalance_cb.offsetsMtx);
+		for (auto* offset : cl_rebalance_cb.offsets)
+		{
+			delete offset;
+		}
+		cl_rebalance_cb.offsets.clear();
 	}
-	cl_rebalance_cb.offsets.clear();
 
 #ifdef SIMPLEKAFKA_HAS_OPENSSL
 	for (OSSL_PROVIDER* provider : loadedSslProviderHandles)

--- a/src/SimpleKafka1C.h
+++ b/src/SimpleKafka1C.h
@@ -385,6 +385,10 @@ private:
 	public:
 
 		std::vector<RdKafka::TopicPartition*> offsets;
+		// offsets трогают два потока: поток 1С (SetReadingPosition/SetReadingPositions,
+		// деструктор компоненты) и фоновый поток librdkafka (rebalance_cb). Без защиты
+		// возможны гонка на векторе и двойное освобождение TopicPartition.
+		std::mutex offsetsMtx;
 
 		void rebalance_cb(RdKafka::KafkaConsumer* consumer,
 			RdKafka::ErrorCode err,

--- a/src/consumer_methods.cpp
+++ b/src/consumer_methods.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <cmath>
 #include <limits>
+#include <memory>
 
 //================================== Consumer ==========================================
 
@@ -284,7 +285,10 @@ bool SimpleKafka1C::setReadingPosition(const variant_t& topicName, const variant
 	}
 
 	RdKafka::TopicPartition* ptr = RdKafka::TopicPartition::create(assignTopic, assignPartition, assignOffset);
-	cl_rebalance_cb.offsets.push_back(ptr);
+	{
+		std::lock_guard<std::mutex> lk(cl_rebalance_cb.offsetsMtx);
+		cl_rebalance_cb.offsets.push_back(ptr);
+	}
 	return true;
 }
 
@@ -384,10 +388,13 @@ bool SimpleKafka1C::setReadingPositions(const variant_t& jsonTopicPartitions, co
 	}
 
 	// All entries valid - apply them
-	for (const auto& entry : entries)
 	{
-		RdKafka::TopicPartition* ptr = RdKafka::TopicPartition::create(entry.topic, entry.partition, entry.offset);
-		cl_rebalance_cb.offsets.push_back(ptr);
+		std::lock_guard<std::mutex> lk(cl_rebalance_cb.offsetsMtx);
+		for (const auto& entry : entries)
+		{
+			RdKafka::TopicPartition* ptr = RdKafka::TopicPartition::create(entry.topic, entry.partition, entry.offset);
+			cl_rebalance_cb.offsets.push_back(ptr);
+		}
 	}
 
 	return true;
@@ -406,7 +413,7 @@ std::string SimpleKafka1C::consume()
 	std::ofstream eventFile{};
 	boost::property_tree::ptree jsonObj;
 	RdKafka::Headers* headers;
-	RdKafka::Message* msg = hConsumer->consume(waitMessageTimeout);
+	std::unique_ptr<RdKafka::Message> msg(hConsumer->consume(waitMessageTimeout));
 	RdKafka::ErrorCode resultConsume = msg->err();
 
 	openEventFile(consumerLogName, eventFile);
@@ -450,8 +457,6 @@ std::string SimpleKafka1C::consume()
 		{
 			jsonObj.put_child("headers", headersChildren);
 		}
-
-		delete msg;
 	}
 	else
 	{
@@ -462,7 +467,6 @@ std::string SimpleKafka1C::consume()
 				eventFile << currentDateTime() << " Error: " << msg_err << std::endl;
 			}
 		}
-		delete msg;
 		return EMPTYSTR;
 	}
 	boost::property_tree::write_json(s, jsonObj, true);
@@ -478,7 +482,7 @@ bool SimpleKafka1C::getMessage()
 		return false;
 	}
 
-	RdKafka::Message* msg = hConsumer->consume(waitMessageTimeout);
+	std::unique_ptr<RdKafka::Message> msg(hConsumer->consume(waitMessageTimeout));
 	RdKafka::ErrorCode resultConsume = msg->err();
 
 	std::ofstream eventFile;
@@ -489,9 +493,9 @@ bool SimpleKafka1C::getMessage()
 	{
 		this->messageLen = msg->len();
 
-		u_char* charBuf = (u_char*)msg->payload();
-		std::vector<char> binaryData(charBuf, charBuf + this->messageLen);
-		messageData = binaryData;
+		// Тело кладём сразу в messageData, без промежуточной копии вектора.
+		const char* charBuf = static_cast<const char*>(msg->payload());
+		messageData.assign(charBuf, charBuf + this->messageLen);
 
 		if (msg->key() && (*msg->key()).length() > 0)
 		{
@@ -523,8 +527,6 @@ bool SimpleKafka1C::getMessage()
 		// Обновляем метрики консьюмера
 		consumerMetrics.messagesConsumed++;
 		consumerMetrics.bytesConsumed += this->messageLen;
-
-		delete msg;
 	}
 	else
 	{
@@ -536,7 +538,6 @@ bool SimpleKafka1C::getMessage()
 			consumerMetrics.errorsCount++;
 			if (eventFile.is_open()) eventFile << currentDateTime() << " Error: " << msg_err << std::endl;
 		}
-		delete msg;
 		return false;
 	}
 
@@ -572,7 +573,7 @@ std::string SimpleKafka1C::consumeBatch(const variant_t& maxMessages, const vari
 		int32_t remainingWait = static_cast<int32_t>(maxWait - elapsed);
 		if (remainingWait <= 0) remainingWait = 1;
 
-		RdKafka::Message* msg = hConsumer->consume(waitMessageTimeout);
+		std::unique_ptr<RdKafka::Message> msg(hConsumer->consume(waitMessageTimeout));
 		if (!msg)
 		{
 			msg_err = "Consumer returned null message";
@@ -702,8 +703,6 @@ std::string SimpleKafka1C::consumeBatch(const variant_t& maxMessages, const vari
 			msg_err = msg->errstr();
 			consumerMetrics.errorsCount++;
 		}
-
-		delete msg;
 	}
 
 	boost::json::object result;


### PR DESCRIPTION
Два независимых, но однотипных места в консьюмере.

### 1. Утечка сообщения на исключении

`Consume`, `GetMessage` и `ConsumeBatch` держат `RdKafka::Message*` сырым указателем и освобождают его вручную в конце каждой ветки. Между `consume()` и `delete` работают boost::property_tree и boost::json — они бросают исключения, и тогда `delete` не выполняется. На потоке чтения это утечка на каждом сбое разбора.

В admin-методах и в `ReadMessageByOffset` сообщения у вас уже под `unique_ptr` — здесь сделано так же, ручные `delete msg` убраны.

### 2. Гонка на offsets ребаланса

`clRebalanceCb::offsets` пишет поток 1С (`SetReadingPosition`, `SetReadingPositions`, деструктор компоненты), а читает и очищает фоновый поток librdkafka в `rebalance_cb`. Синхронизации не было — возможна гонка на векторе и двойное освобождение `TopicPartition`. Добавлен мьютекс рядом с самим вектором, берётся только на время работы с ним; в `rebalance_cb` он охватывает всю обработку назначения партиций.

### Побочно

`GetMessage` больше не копирует тело дважды: `messageData.assign(...)` вместо промежуточного `std::vector<char>`. На телах в сотни килобайт это заметно.

Проверено сборкой Release на Windows, MSVC, триплет x64-windows-static.
