### PR TITLE
Настройки: upsert по ключу и понятная ошибка вместо bad_variant_access

### DIFF
--- a/src/SimpleKafka1C.cpp
+++ b/src/SimpleKafka1C.cpp
@@ -583,7 +583,26 @@ SimpleKafka1C::~SimpleKafka1C()
 
 void SimpleKafka1C::setParameter(const variant_t& key, const variant_t& value)
 {
-	settings.push_back({ std::get<std::string>(key), std::get<std::string>(value) });
+	if (!std::holds_alternative<std::string>(key) || !std::holds_alternative<std::string>(value))
+	{
+		msg_err = "SetParameter: key and value must be strings";
+		return;
+	}
+	const std::string k = std::get<std::string>(key);
+	const std::string v = std::get<std::string>(value);
+
+	// Один ключ — одно значение. Иначе на переиспользуемом экземпляре компоненты
+	// настройки копятся дублями, а clientID() (берёт первое значение) и
+	// getSettingValue() (последнее) начинают расходиться.
+	for (auto& s : settings)
+	{
+		if (s.Key == k)
+		{
+			s.Value = v;
+			return;
+		}
+	}
+	settings.push_back({ k, v });
 }
 
 std::string SimpleKafka1C::getParameters()
@@ -626,8 +645,20 @@ bool SimpleKafka1C::setPartitioner(const variant_t& partitionerType)
 	}
 
 	partitionerStrategy = type;
-	// Устанавливаем параметр через setParameter для применения при инициализации продюсера
-	settings.push_back({ "partitioner", type });
+	// Применится при инициализации продюсера. Тоже upsert, чтобы повторные вызовы
+	// не плодили дубли "partitioner".
+	bool found = false;
+	for (auto& s : settings)
+	{
+		if (s.Key == "partitioner")
+		{
+			s.Value = type;
+			found = true;
+			break;
+		}
+	}
+	if (!found)
+		settings.push_back({ "partitioner", type });
 	return true;
 }
 

--- a/src/producer_methods.cpp
+++ b/src/producer_methods.cpp
@@ -150,6 +150,22 @@ int32_t SimpleKafka1C::produce(const variant_t& msg, const variant_t& topicName,
 		return -1;
 	}
 
+	// Проверяем типы параметров, чтобы вместо невнятного bad_variant_access
+	// вернуть в 1С понятный текст (тело допускается строкой или ДвоичнымиДанными).
+	if (!std::holds_alternative<std::string>(topicName) ||
+		!std::holds_alternative<int32_t>(partition) ||
+		!std::holds_alternative<std::string>(key) ||
+		!std::holds_alternative<std::string>(heads))
+	{
+		msg_err = "produce: topicName/key/headers must be strings and partition must be a number";
+		return -1;
+	}
+	if (!std::holds_alternative<std::string>(msg) && !std::holds_alternative<std::vector<char>>(msg))
+	{
+		msg_err = "produce: message must be a string or binary data";
+		return -1;
+	}
+
 	std::string tTopicName = std::get<std::string>(topicName);
 	auto currentPartition = std::get<int>(partition);
 


### PR DESCRIPTION
Две мелочи в обработке входных параметров, обе всплыли на долгоживущем экземпляре компоненты.

### Дубли настроек

`SetParameter` складывает пару ключ-значение в вектор без проверки. В фоновом задании 1С экземпляр живёт часами, и повторный вызов с тем же ключом добавляет ещё одну запись. При применении настроек побеждает последняя, а `clientID()` читает первую — `client.id` в логах перестаёт соответствовать реально применённой конфигурации. `SetPartitioner` добавлял `"partitioner"` тем же способом.

Теперь оба делают upsert: один ключ — одно значение.

### Понятный текст вместо bad_variant_access

`std::get<std::string>` на нестроковом значении бросает `bad_variant_access`, и в 1С прилетает текст исключения C++ без указания метода и параметра. `SetParameter` и `Produce` теперь проверяют типы и возвращают внятное сообщение, какой параметр каким должен быть. Тело сообщения в `Produce` по-прежнему принимается и строкой, и двоичными данными.

Проверено сборкой Release на Windows, MSVC, x64-windows-static.
