### PR TITLE
Обновление схемы применяется: кэш текста в PutAvroSchema и PutProtoSchema

### DIFF
--- a/src/SimpleKafka1C.h
+++ b/src/SimpleKafka1C.h
@@ -115,6 +115,7 @@ private:
 
 	// avro
 	std::map<std::string, avro::ValidSchema> schemesMap;	// кеш для хранение компилированных схем Avro
+	std::map<std::string, std::string> schemaTexts;	// исходный текст схемы по имени — чтобы не компилировать неизменившуюся
 	std::vector<uint8_t> avroFile;		// формируемый avro
 
 	// protobuf - using forward declarations to avoid including protobuf headers in .h

--- a/src/avro_methods.cpp
+++ b/src/avro_methods.cpp
@@ -603,15 +603,21 @@ bool SimpleKafka1C::putAvroSchema(const variant_t& schemaJsonName, const variant
 {
 	try
 	{
-		// Проверяем, существует ли схема с таким именем
-		auto it = schemesMap.find(std::get<std::string>(schemaJsonName));
+		const std::string& name = std::get<std::string>(schemaJsonName);
+		const std::string& json = std::get<std::string>(schemaJson);
 
-		if (it == schemesMap.end())
+		// Компилируем, если схемы с таким именем ещё нет ИЛИ её текст изменился.
+		// Прежнее поведение (register-once) молча игнорировало обновление схемы:
+		// в переиспользуемом экземпляре компоненты застревала первая версия.
+		// Кэш по тексту заодно бережёт CPU — 1С часто зовёт метод перед каждым сообщением.
+		auto known = schemaTexts.find(name);
+		if (known != schemaTexts.end() && known->second == json)
 		{
-			// Схема не существует, компилируем и добавляем ее в map
-			const avro::ValidSchema compiledScheme = avro::compileJsonSchemaFromString(std::get<std::string>(schemaJson));
-			schemesMap[std::get<std::string>(schemaJsonName)] = compiledScheme;
+			return true;	// тот же текст, схема уже скомпилирована
 		}
+
+		schemesMap[name] = avro::compileJsonSchemaFromString(json);
+		schemaTexts[name] = json;
 	}
 	catch (std::exception const& ex)
 	{

--- a/src/protobuf_methods.cpp
+++ b/src/protobuf_methods.cpp
@@ -157,10 +157,47 @@ class SimpleKafka1C::ProtobufContext
 {
 public:
 	std::map<std::string, const google::protobuf::Descriptor*> descriptors;
+	std::map<std::string, std::string> schemaTexts;	// исходный текст .proto по имени схемы
 	google::protobuf::DescriptorPool pool;
 	google::protobuf::DynamicMessageFactory factory;
 
 	ProtobufContext() : factory(&pool) {}
+
+	// Разбирает текст .proto и регистрирует его в ЭТОМ пуле под именем name.
+	// Один пул — одна регистрация каждого символа, поэтому обновление схемы
+	// делается пересборкой контекста целиком (см. putProtoSchema).
+	bool build(const std::string& name, const std::string& schema, std::string& err)
+	{
+		google::protobuf::io::ArrayInputStream input(schema.data(), static_cast<int>(schema.size()));
+		google::protobuf::io::Tokenizer tokenizer(&input, nullptr);
+
+		google::protobuf::compiler::Parser parser;
+		google::protobuf::FileDescriptorProto fileDescProto;
+		fileDescProto.set_name(name + ".proto");
+
+		if (!parser.Parse(&tokenizer, &fileDescProto))
+		{
+			err = "Proto schema parsing error (schema '" + name + "')";
+			return false;
+		}
+
+		const google::protobuf::FileDescriptor* fileDesc = pool.BuildFile(fileDescProto);
+		if (!fileDesc)
+		{
+			err = "Failed to build descriptor from proto schema '" + name + "'";
+			return false;
+		}
+
+		if (fileDesc->message_type_count() == 0)
+		{
+			err = "Proto schema '" + name + "' contains no message definitions";
+			return false;
+		}
+
+		descriptors[name] = fileDesc->message_type(0);
+		schemaTexts[name] = schema;
+		return true;
+	}
 };
 
 bool SimpleKafka1C::putProtoSchema(const variant_t& schemaName, const variant_t& protoSchema)
@@ -175,47 +212,32 @@ bool SimpleKafka1C::putProtoSchema(const variant_t& schemaName, const variant_t&
 		std::string name = std::get<std::string>(schemaName);
 		std::string schema = std::get<std::string>(protoSchema);
 
-		// Check if schema already exists
-		auto it = protoContext->descriptors.find(name);
-		if (it != protoContext->descriptors.end())
+		// Тот же текст — работать не нужно; изменившийся — применяем.
+		// Прежнее поведение (skip if exists) молча игнорировало обновление схемы.
+		auto known = protoContext->schemaTexts.find(name);
+		if (known != protoContext->schemaTexts.end())
 		{
-			// Schema already exists, skip
+			if (known->second == schema)
+				return true;
+
+			// DescriptorPool не допускает повторного объявления символа, поэтому
+			// обновление = чистый контекст со всеми известными схемами. Прежний
+			// контекст жив, пока на него кто-то ссылается, подмена безопасна.
+			auto texts = protoContext->schemaTexts;
+			texts[name] = schema;
+
+			auto fresh = std::make_shared<ProtobufContext>();
+			for (const auto& kv : texts)
+			{
+				if (!fresh->build(kv.first, kv.second, msg_err))
+					return false;
+			}
+			protoContext = fresh;
 			return true;
 		}
 
-		// Parse the .proto schema
-		google::protobuf::io::ArrayInputStream input(schema.data(), static_cast<int>(schema.size()));
-		google::protobuf::io::Tokenizer tokenizer(&input, nullptr);
-
-		google::protobuf::compiler::Parser parser;
-		google::protobuf::FileDescriptorProto fileDescProto;
-		fileDescProto.set_name(name + ".proto");
-
-		if (!parser.Parse(&tokenizer, &fileDescProto))
-		{
-			msg_err = "Proto schema parsing error";
+		if (!protoContext->build(name, schema, msg_err))
 			return false;
-		}
-
-		// Build descriptor from FileDescriptorProto
-		const google::protobuf::FileDescriptor* fileDesc = protoContext->pool.BuildFile(fileDescProto);
-		if (!fileDesc)
-		{
-			msg_err = "Failed to build descriptor from proto schema";
-			return false;
-		}
-
-		// Find the message type (assuming first message in file)
-		if (fileDesc->message_type_count() > 0)
-		{
-			const google::protobuf::Descriptor* descriptor = fileDesc->message_type(0);
-			protoContext->descriptors[name] = descriptor;
-		}
-		else
-		{
-			msg_err = "Proto schema contains no message definitions";
-			return false;
-		}
 	}
 	catch (std::exception const& ex)
 	{


### PR DESCRIPTION
### Что происходит

`PutAvroSchema` компилирует схему, только если имени ещё нет в `schemesMap`. `PutProtoSchema` при найденном имени просто выходит с `Истина`. То есть повторный вызов с **изменённым** текстом схемы молча игнорируется.

В 1С компонента обычно живёт в фоновом задании часами. После эволюции схемы в реестре база начинает передавать новый текст, а внутри остаётся первая версия: сообщения либо перестают декодироваться, либо кодируются старым набором полей. Ошибки при этом нет никакой — метод вернул `Истина`.

### Что в PR

Рядом с компилированной схемой хранится её исходный текст:

- тот же текст — выходим сразу. Заодно экономия: 1С часто вызывает метод перед каждым сообщением, а компиляция схемы не бесплатна;
- изменившийся текст — применяем.

Для protobuf «применить» сложнее: `DescriptorPool` не допускает повторного объявления того же символа, а регистрация под другим именем файла упирается в то же самое и вдобавок растит пул на каждый вызов. Поэтому при изменении текста собирается чистый `ProtobufContext` со всеми известными схемами и подменяется целиком; прежний контекст живёт, пока на него кто-то ссылается (`shared_ptr`), так что подмена безопасна.

Проверено сборкой Release на Windows, MSVC, x64-windows-static.
