### PR TITLE
AVRO: явный параметр IsBase64 у DecodeAvroMessage/GetAvroSchema

### DIFF
--- a/src/SimpleKafka1C.cpp
+++ b/src/SimpleKafka1C.cpp
@@ -520,8 +520,9 @@ SimpleKafka1C::SimpleKafka1C()
 		{ {1, -1}, {3, std::string("")}, {4, std::string("")} });
 	AddMethod(L"SaveAvroFile", L"СохранитьФайлAVRO", this, &SimpleKafka1C::saveAvroFile);
 	AddMethod(L"DecodeAvroMessage", L"ДекодироватьСообщениеAVRO", this, &SimpleKafka1C::decodeAvroMessage,
-		{ {1, std::string("")}, {2, true} });
-	AddMethod(L"GetAvroSchema", L"ПолучитьСхемуAVRO", this, &SimpleKafka1C::getAvroSchema);
+		{ {1, std::string("")}, {2, true}, {3, false} });
+	AddMethod(L"GetAvroSchema", L"ПолучитьСхемуAVRO", this, &SimpleKafka1C::getAvroSchema,
+		{ {1, false} });
 
 	// Protobuf
 	AddMethod(L"PutProtoSchema", L"СохранитьСхемуProtobuf", this, &SimpleKafka1C::putProtoSchema);

--- a/src/SimpleKafka1C.h
+++ b/src/SimpleKafka1C.h
@@ -302,8 +302,8 @@ private:
 	bool putAvroSchema(const variant_t &schemaJsonName, const variant_t &schemaJson);
 	bool convertToAvroFormat(const variant_t &msgJson, const variant_t &schemaJsonName, const variant_t &format, const variant_t &schemaId);
 	bool saveAvroFile(const variant_t &fileName);
-	variant_t decodeAvroMessage(const variant_t &avroData, const variant_t &schemaJsonName, const variant_t &asJson);
-	variant_t getAvroSchema(const variant_t &avroData);
+	variant_t decodeAvroMessage(const variant_t &avroData, const variant_t &schemaJsonName, const variant_t &asJson, const variant_t &isBase64);
+	variant_t getAvroSchema(const variant_t &avroData, const variant_t &isBase64);
 
 	// converting a message to protobuf format
 	bool putProtoSchema(const variant_t &schemaName, const variant_t &protoSchema);

--- a/src/avro_methods.cpp
+++ b/src/avro_methods.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 
 #include "SimpleKafka1C.h"
+#include "utils.h"
 
 //================================== Avro logical types: helpers ==================
 
@@ -1469,13 +1470,14 @@ static std::string convertAvroDatumToJsonString(const avro::GenericDatum& datum)
 	return oss.str();
 }
 
-variant_t SimpleKafka1C::decodeAvroMessage(const variant_t& avroData, const variant_t& schemaJsonName, const variant_t& asJson)
+variant_t SimpleKafka1C::decodeAvroMessage(const variant_t& avroData, const variant_t& schemaJsonName, const variant_t& asJson, const variant_t& isBase64)
 {
 	try
 	{
 		// Получаем бинарные данные
 		const std::vector<char>* dataPtr = nullptr;
 		size_t dataSize = 0;
+		std::vector<char> decodedBuf;
 
 		if (std::holds_alternative<std::vector<char>>(avroData))
 		{
@@ -1493,6 +1495,22 @@ variant_t SimpleKafka1C::decodeAvroMessage(const variant_t& avroData, const vari
 		{
 			msg_err = "Invalid data type for avroData. Expected string or binary data";
 			return std::string("");
+		}
+
+		// 1C can marshal ДвоичныеДанные into a native method as base64 text
+		// instead of raw bytes. IsBase64 lets the caller say so explicitly —
+		// no auto-detection: a raw payload could coincidentally consist
+		// entirely of base64-alphabet bytes, so guessing is unsafe.
+		if (std::holds_alternative<bool>(isBase64) && std::get<bool>(isBase64))
+		{
+			const std::string origStr(dataPtr->begin(), dataPtr->begin() + dataSize);
+			if (!tryBase64Decode(origStr, decodedBuf))
+			{
+				msg_err = "IsBase64=true, but input is not valid base64";
+				return std::string("");
+			}
+			dataPtr = &decodedBuf;
+			dataSize = decodedBuf.size();
 		}
 
 		if (dataSize == 0)
@@ -1682,13 +1700,14 @@ variant_t SimpleKafka1C::decodeAvroMessage(const variant_t& avroData, const vari
 	}
 }
 
-variant_t SimpleKafka1C::getAvroSchema(const variant_t& avroData)
+variant_t SimpleKafka1C::getAvroSchema(const variant_t& avroData, const variant_t& isBase64)
 {
 	try
 	{
 		// Получаем бинарные данные
 		const std::vector<char>* dataPtr = nullptr;
 		size_t dataSize = 0;
+		std::vector<char> decodedBuf;
 
 		if (std::holds_alternative<std::vector<char>>(avroData))
 		{
@@ -1706,6 +1725,19 @@ variant_t SimpleKafka1C::getAvroSchema(const variant_t& avroData)
 		{
 			msg_err = "Invalid data type for avroData. Expected string or binary data";
 			return std::string("");
+		}
+
+		// See decodeAvroMessage() for why this is an explicit flag, not a guess.
+		if (std::holds_alternative<bool>(isBase64) && std::get<bool>(isBase64))
+		{
+			const std::string origStr(dataPtr->begin(), dataPtr->begin() + dataSize);
+			if (!tryBase64Decode(origStr, decodedBuf))
+			{
+				msg_err = "IsBase64=true, but input is not valid base64";
+				return std::string("");
+			}
+			dataPtr = &decodedBuf;
+			dataSize = decodedBuf.size();
 		}
 
 		if (dataSize == 0)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -31,6 +31,69 @@ std::string base64Encode(const uint8_t* data, size_t len)
 	return out;
 }
 
+bool tryBase64Decode(const std::string& input, std::vector<char>& out)
+{
+	auto val = [](unsigned char c) -> int {
+		if (c >= 'A' && c <= 'Z') return c - 'A';
+		if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+		if (c >= '0' && c <= '9') return c - '0' + 52;
+		if (c == '+' || c == '-') return 62; // '-' = URL-safe
+		if (c == '/' || c == '_') return 63; // '_' = URL-safe
+		return -1;
+	};
+
+	std::vector<int> sextets;
+	sextets.reserve(input.size());
+	for (unsigned char c : input)
+	{
+		if (c == '=') break; // padding -> end of meaningful data
+		if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+			continue; // skip whitespace / line breaks
+		const int v = val(c);
+		if (v < 0)
+			return false; // not valid base64
+		sextets.push_back(v);
+	}
+
+	const size_t k = sextets.size();
+	if (k == 0 || (k % 4) == 1)
+		return false;
+
+	std::vector<char> result;
+	result.reserve((k / 4) * 3 + 2);
+
+	size_t i = 0;
+	for (; i + 4 <= k; i += 4)
+	{
+		const uint32_t t = (static_cast<uint32_t>(sextets[i]) << 18) |
+		                   (static_cast<uint32_t>(sextets[i + 1]) << 12) |
+		                   (static_cast<uint32_t>(sextets[i + 2]) << 6) |
+		                   static_cast<uint32_t>(sextets[i + 3]);
+		result.push_back(static_cast<char>((t >> 16) & 0xFF));
+		result.push_back(static_cast<char>((t >> 8) & 0xFF));
+		result.push_back(static_cast<char>(t & 0xFF));
+	}
+
+	const size_t rem = k - i;
+	if (rem == 2) // final group encodes 1 byte
+	{
+		const uint32_t t = (static_cast<uint32_t>(sextets[i]) << 18) |
+		                   (static_cast<uint32_t>(sextets[i + 1]) << 12);
+		result.push_back(static_cast<char>((t >> 16) & 0xFF));
+	}
+	else if (rem == 3) // final group encodes 2 bytes
+	{
+		const uint32_t t = (static_cast<uint32_t>(sextets[i]) << 18) |
+		                   (static_cast<uint32_t>(sextets[i + 1]) << 12) |
+		                   (static_cast<uint32_t>(sextets[i + 2]) << 6);
+		result.push_back(static_cast<char>((t >> 16) & 0xFF));
+		result.push_back(static_cast<char>((t >> 8) & 0xFF));
+	}
+
+	out = std::move(result);
+	return true;
+}
+
 bool isValidUtf8(const char* data, size_t len)
 {
 	size_t i = 0;

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,11 +2,17 @@
 #define KAFKA_UTILS_H
 
 #include <string>
+#include <vector>
 #include <cstddef>
 #include <cstdint>
 
 // String utilities
 std::string base64Encode(const uint8_t* data, size_t len);
+// Decode a strictly-valid base64 string into raw bytes. Returns false (and
+// leaves out untouched) if the input is not pure, correctly-padded base64.
+// Tolerates both alphabets ('+/' and URL-safe '-_'), optional '=' padding,
+// and whitespace/line breaks anywhere in the input.
+bool tryBase64Decode(const std::string& input, std::vector<char>& out);
 bool isValidUtf8(const char* data, size_t len);
 
 // Date/time utilities


### PR DESCRIPTION
1С в ряде случаев маршалит `ДвоичныеДанные`, переданные в нативный метод, как base64-текст вместо
сырых байт — сейчас это ломает декодирование Avro без внятного сигнала о причине.

Обсуждали в #87: вариант с автораспознаванием отклонён как «закрытый ящик» — сырой payload
теоретически может целиком состоять из символов алфавита base64, поэтому угадывать небезопасно,
надёжно знает только вызывающий. Этот PR реализует выбранный вариант — явный флаг.

**Что меняется**

Необязательный параметр `IsBase64` у `DecodeAvroMessage`/`ДекодироватьСообщениеAVRO` (4-й) и
`GetAvroSchema`/`ПолучитьСхемуAVRO` (2-й), по умолчанию `false` — существующие вызовы не затронуты:

- `false` / не передан — байты берутся как есть, ровно как сейчас;
- `true` — вход сначала декодируется из base64 (`tryBase64Decode` в `utils.cpp`, оба алфавита —
  стандартный и URL-safe, с паддингом и без, устойчив к переносам строк); если он не является
  валидным base64 — явная ошибка через `GetLastError`/`ПолучитьОписаниеОшибки`, без молчаливого
  фолбэка на сырые байты.

Автораспознавание нигде не добавлено — поведение по умолчанию не меняется.

**Как проверено**

Собрано Release на Windows (MSVC, x64-windows-static). Отдельно прогнан standalone-тест логики на
реальном `tryBase64Decode`/`utils.cpp` этой ветки: валидный base64 с `IsBase64=true` декодируется,
Confluent-заголовок (`0x00`, не base64) с `IsBase64=true` даёт явную ошибку вместо тихого фолбэка,
`IsBase64=false`/не передан оставляет байты как есть в обоих случаях (в т.ч. когда они случайно
похожи на валидный base64) — 4/4.
